### PR TITLE
Enable CORS headers support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ if(ENABLE_EMULATOR)
     list(APPEND VCPKG_MANIFEST_FEATURES "emulator")
 endif()
 
+# Option to enable/disable CORS headers
+option(ENABLE_CORS "Enable CORS headers for cross-origin requests" OFF)
+
 project(main VERSION 0.1.0)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
@@ -59,6 +62,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Main Target Compile
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+
+# Add CORS support if enabled
+if(ENABLE_CORS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_CORS)
+endif()
 
 # Require SharedTools
 target_link_libraries(${PROJECT_NAME} PRIVATE SharedTools)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,7 @@
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
                 "CMAKE_MAKE_PROGRAM": "ninja",
                 "ENABLE_EMULATOR": true,
+                "ENABLE_CORS": true,
                 "SKIP_WEB_BUILD": true,
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }

--- a/plugins/SpotifyScenes/SpotifyScenes.cpp
+++ b/plugins/SpotifyScenes/SpotifyScenes.cpp
@@ -60,9 +60,10 @@ register_routes(std::unique_ptr<router_t> router) {
                                  << "&redirect_uri=" << redirect_uri
                                  << "&state=" << state;
 
-                         return req->create_response(restinio::status_temporary_redirect())
-                                 .append_header(restinio::http_field::location, auth_url.str())
-                                 .done();
+                         auto response = req->create_response(restinio::status_temporary_redirect())
+                                 .append_header(restinio::http_field::location, auth_url.str());
+                         Server::add_cors_headers(response);
+                         return response.done();
                      });
 
     router->http_get("/spotify/callback",
@@ -72,9 +73,10 @@ register_routes(std::unique_ptr<router_t> router) {
                          const auto state = !qp.has("state") ? "" : std::string{qp["state"]};
 
                          if (state.empty()) {
-                             return req->create_response(restinio::status_bad_request())
-                                     .set_body("State mismatch")
-                                     .done();
+                             auto response = req->create_response(restinio::status_bad_request())
+                                     .set_body("State mismatch");
+                             Server::add_cors_headers(response);
+                             return response.done();
                          }
 
                          if (!code.empty()) {
@@ -96,9 +98,10 @@ register_routes(std::unique_ptr<router_t> router) {
                              return Server::reply_with_json(req, {{"success", true}});
                          }
 
-                         return req->create_response(restinio::status_bad_request())
-                                 .set_body("Missing code parameter")
-                                 .done();
+                         auto response = req->create_response(restinio::status_bad_request())
+                                 .set_body("Missing code parameter");
+                         Server::add_cors_headers(response);
+                         return response.done();
                      });
 
     return std::move(router);

--- a/run_emulator.sh
+++ b/run_emulator.sh
@@ -7,7 +7,7 @@ else
     echo "Environment file '.env' not found. You can create one if you want"
 fi
 
-cmake -B emulator_build -S .
+cmake --preset emulator
 cmake --build emulator_build --target install
 if [ $? -ne 0 ]; then
     echo "Build failed. Please check the output for errors."

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -34,6 +34,11 @@ add_library(${PROJECT_NAME} SHARED
 # Main Target Compile
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+
+# Add CORS support if enabled
+if(ENABLE_CORS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_CORS)
+endif()
 target_include_directories(${PROJECT_NAME}
         PRIVATE
         # where the library itself will look for its internal headers

--- a/shared/include/shared/server/server_utils.h
+++ b/shared/include/shared/server/server_utils.h
@@ -8,6 +8,18 @@ namespace Server {
     using namespace restinio;
     using json = nlohmann::json;
 
+    // Helper function to add CORS headers if enabled
+    template<typename ResponseBuilder>
+    ResponseBuilder& add_cors_headers(ResponseBuilder& response_builder) {
+#ifdef ENABLE_CORS
+        response_builder.append_header("Access-Control-Allow-Origin", "*");
+        response_builder.append_header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        response_builder.append_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
+        response_builder.append_header("Access-Control-Max-Age", "86400"); // 24 hours
+#endif
+        return response_builder;
+    }
+
     restinio::request_handling_status_t reply_with_json(const request_handle_t &req, const json &j,
                                                         http_status_line_t status = status_ok());
 
@@ -15,4 +27,7 @@ namespace Server {
                                                http_status_line_t status = status_bad_request());
 
     restinio::request_handling_status_t reply_success(const request_handle_t &req);
+
+    // Handle CORS preflight requests
+    restinio::request_handling_status_t handle_cors_preflight(const request_handle_t &req);
 }

--- a/shared/src/shared/server/server_utils.cpp
+++ b/shared/src/shared/server/server_utils.cpp
@@ -13,11 +13,13 @@ namespace Server {
 
     request_handling_status_t reply_with_json(const request_handle_t &req, const json &j,
                                                         http_status_line_t status) {
-        return req->create_response(std::move(status))
+        auto response = req->create_response(std::move(status))
                 .append_header_date_field()
-                .append_header(http_field::content_type, "application/json; charset=utf-8")
-                .set_body(to_string(j))
-                .done();
+                .append_header(http_field::content_type, "application/json; charset=utf-8");
+        
+        add_cors_headers(response);
+        
+        return response.set_body(to_string(j)).done();
     }
 
     request_handling_status_t reply_with_error(const request_handle_t &req, const string msg, http_status_line_t status) {
@@ -26,5 +28,18 @@ namespace Server {
 
     request_handling_status_t reply_success(const request_handle_t &req) {
         return reply_with_json(req, json{{"success", true}});
+    }
+
+    request_handling_status_t handle_cors_preflight(const request_handle_t &req) {
+#ifdef ENABLE_CORS
+        auto response = req->create_response(status_ok())
+                .append_header_date_field();
+        
+        add_cors_headers(response);
+        
+        return response.done();
+#else
+        return req->create_response(status_method_not_allowed()).done();
+#endif
     }
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -8,6 +8,8 @@
 #include "other_routes.h"
 #include "preset_management.h"
 #include "scene_management.h"
+#include "shared/server/server_utils.h"
+#include <spdlog/spdlog.h>
 
 using namespace std;
 using namespace restinio;
@@ -17,6 +19,14 @@ using json = nlohmann::json;
 // Create request handler.
 std::unique_ptr<router_t> Server::server_handler() {
     auto router = std::make_unique<router_t>();
+
+#ifdef ENABLE_CORS
+    // Handle CORS preflight requests for all routes
+    router->add_handler(http_method_options(), R"(.*)", [](auto req, auto) {
+        return Server::handle_cors_preflight(req);
+    });
+    spdlog::debug("Allowing CORS requests");
+#endif
 
     router = add_preset_routes(std::move(router));
     router = add_canvas_status_routes(std::move(router));


### PR DESCRIPTION
Introduce an option to enable CORS headers for cross-origin requests, enhancing the server's ability to handle such requests. This includes modifications to response handling and the addition of a preflight request handler.