### PR TITLE
Set cache-control Header for static files

### DIFF
--- a/react-native/app/index.tsx
+++ b/react-native/app/index.tsx
@@ -82,10 +82,6 @@ export default function Screen() {
     }
   }
 
-  console.log("App version:", appVersion);
-  console.log("Matrix version:", matrixVersion);
-  console.log("Show version warning:", showVersionWarning, "Type:", warningType);
-
 
   return (
     <SafeAreaProvider>

--- a/shared/matrix/include/shared/matrix/server/common.h
+++ b/shared/matrix/include/shared/matrix/server/common.h
@@ -10,7 +10,7 @@ namespace Server {
     using traits_t =
         restinio::traits_t<
             restinio::asio_timer_manager_t,
-            restinio::null_logger_t,
+            restinio::single_threaded_ostream_logger_t,
             router_t>;
 
     // Alias for container with stored websocket handles.

--- a/src_matrix/main.cpp
+++ b/src_matrix/main.cpp
@@ -138,9 +138,6 @@ int main(int argc, char *argv[])
             settings.port(port);
             settings.address(host);
             settings.request_handler(std::move(router));
-            settings.read_next_http_message_timelimit(10s);
-            settings.write_http_response_timelimit(1s);
-            settings.handle_request_timeout(1s);
             settings.cleanup_func([]
                                   { 
             std::unique_lock lock(Server::registryMutex);

--- a/src_matrix/server/other_routes.cpp
+++ b/src_matrix/server/other_routes.cpp
@@ -57,7 +57,8 @@ std::unique_ptr<Server::router_t> Server::add_other_routes(std::unique_ptr<route
         spdlog::trace("Serving {}", file_path.c_str());
         auto response = req->create_response(restinio::status_ok())
             .append_header_date_field()
-            .append_header(restinio::http_field::content_type, content_type);
+            .append_header(restinio::http_field::content_type, content_type)
+            .append_header(restinio::http_field::cache_control, "public, max-age=31536000");
         Server::add_cors_headers(response);
         return response.set_body(restinio::sendfile(file_path)).done(); });
 


### PR DESCRIPTION
Currently, when opening the web interface and the rpi is too slow to send a response, invalid javascript is returned. By increasing timeout limits and setting the Cache-Control header, javascript files are now sent properly.
